### PR TITLE
Adding SF Bay area rail data.

### DIFF
--- a/rlist_files/imgoph.list
+++ b/rlist_files/imgoph.list
@@ -42,6 +42,16 @@ MA GreLnD Riv GovCen
 CA A WilRosaPar 7thStMetCen
 CA C AviLAX WilRosaPar
 CA E ExpoSep 7thStMetCen
+CA CT Tam SanFraKing
+CA BARTGre MonSt Fre
+CA BARTOra Fre DtnBer
+CA BARTRed MonSt DtnBer
+CA BARTYel MonSt Ori
+CA BARTBlue MonSt +DIV_BLUE
+CA MuniN Noe 4thKing
+CA VTABlue ChiDisMus +DIV_TAS
+CA VTAGre Cam OldIro
+CA VTAOra DtnMouView +DIV_TAS
 DC DCSC UniSta OklAve
 MD BLRL BalAre MtRoyUofBal
 DC BluLn VA/DC DC/MD


### PR DESCRIPTION
Includes newly mappable rail routes in the SF Bay Area (VTA, Caltrain, BART, Muni).